### PR TITLE
Changing "Next" button path

### DIFF
--- a/episode.json
+++ b/episode.json
@@ -1,2 +1,2 @@
-{"id":"hgwLJtGfFfQ"}
+{"id":"lpzfi8aQeLM"}
 

--- a/index.js
+++ b/index.js
@@ -31,16 +31,44 @@ exec('sudo curl -k -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/loca
     const puppeteer = require('puppeteer');
 
     try {
+        console.log(`Reading episode.json`)
         const epConfJSON = JSON.parse(fs.readFileSync(pathToEpisodeJSON, 'utf-8'));
+        console.log(JSON.stringify(epConfJSON) )
 
         const YT_ID = epConfJSON.id;
         console.log(`Processing: ${YT_ID}`);
         const url = YT_URL + YT_ID;
 
+        function isEmpty(str) {
+            return (str === 'undefined' || !str || str.length === 0 || str === '');
+        }
+
         youtubedl.getInfo(url, function (err, info) {
             if (err) throw err;
-            epConfJSON.title = info.title;
-            epConfJSON.description = info.description;
+
+            console.log(`-- Checking title`);
+            
+            if ( !Object.prototype.hasOwnProperty.call(epConfJSON, 'title') || isEmpty(epConfJSON.title)  ) {
+                if ( isEmpty(info.title)  ) {
+                    epConfJSON.title = 'no title';
+                } else {
+                    epConfJSON.title = info.title;
+                }
+            }
+
+            console.log(`-- Checking description`)
+
+            if ( !Object.prototype.hasOwnProperty.call(epConfJSON, 'description') || isEmpty(epConfJSON.description) ) {
+
+                if( isEmpty(info.description) ) {
+                    epConfJSON.description = 'no description';
+                } else {
+                    epConfJSON.description = info.description;
+                }
+            }
+
+            console.log(`title: ${epConfJSON.title}`)
+            console.log(`description: ${epConfJSON.description}`)
 
             const youtubeDlCommand = `youtube-dl -o ${outputFile} -f bestaudio[ext=webm] ${url}`;
 
@@ -57,7 +85,9 @@ exec('sudo curl -k -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/loca
                 fs.writeFileSync(pathToEpisodeJSON, JSON.stringify(epConfJSON));
 
                 const episode = JSON.parse(fs.readFileSync(pathToEpisodeJSON, 'utf-8'));
-            
+                const jsonEpisode = JSON.stringify(episode)
+                console.log(`-- episode.json: ${jsonEpisode}`);
+
                 (async () => {
                     console.log("Launching puppeteer");
                     const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
@@ -89,14 +119,14 @@ exec('sudo curl -k -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/loca
                     await page.waitForFunction('document.querySelector(".styles__saveButton___lWrNZ").getAttribute("disabled") === null', { timeout: UPLOAD_TIMEOUT });
                     await page.click('.styles__saveButton___lWrNZ');
                     await navigationPromise;
-
-
-                    console.log("Adding title");
-                    await page.waitForSelector('#title');
+                    
+                    console.log("-- Adding title");
+                    await page.waitForSelector('#title', { visible: true });
+                    await page.waitForTimeout(2000);
                     await page.type('#title', episode.title);
-            
-                    console.log("Adding description");
-                    await page.waitForSelector('div[role="textbox"]');
+
+                    console.log("-- Adding description");
+                    await page.waitForSelector('div[role="textbox"]', { visible: true });
                     await page.type('div[role="textbox"]', episode.description);
 
                     console.log("-- Publishing");


### PR DESCRIPTION
The CSS path for the "Next" button on Publish page have changed again, breaking the button click.
This commit is using the button label as search for the "Next" Button. This looks like a more resilient way to look for this button and should avoid problems with future CSS changes on this button ( or until they change the button label ¯\_(ツ)_/¯ ).