### PR TITLE
Fix EPISODE_PATH and point to latest version

### DIFF
--- a/.github/workflows/upload-test.yml
+++ b/.github/workflows/upload-test.yml
@@ -16,4 +16,4 @@ jobs:
         env:
           ANCHOR_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
           ANCHOR_PASSWORD: ${{ secrets.ANCHOR_PASSWORD }}
-          EPISODE_PATH: /github/workflow
+          EPISODE_PATH: /github/workspace

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ env:
    POSTPROCESSOR_ARGS: "ffmpeg:-ac 1"
 ```
 
+# Testing
+This project is a version released project. The github action therefore points to the latest version that is in a known working state.
+To test the latest updates it is neccecary to change the yml file to `uses: Schrodinger-Hat/youtube-to-anchorfm@main`
 # Credits
 
 [@thejoin](https://github.com/thejoin95) & [@wabri](https://github.com/wabri)

--- a/index.js
+++ b/index.js
@@ -100,8 +100,8 @@ exec('sudo curl -k -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/
 
                     console.log("Waiting for upload to finish");
                     await page.waitForTimeout(25 * 1000);
-                    await page.waitForXPath('//button[text()="Save episode" and not(boolean(@disabled))]', { timeout: UPLOAD_TIMEOUT });
-                    const [saveButton] = await page.$x('//button[text()="Save episode" and not(boolean(@disabled))]');
+                    await page.waitForXPath('//div[contains(text(),"Save")]/parent::button[not(boolean(@disabled))]', { timeout: UPLOAD_TIMEOUT });
+                    const [saveButton] = await page.$x('//div[contains(text(),"Save")]/parent::button[not(boolean(@disabled))]');
                     await saveButton.click();
                     await navigationPromise;
 


### PR DESCRIPTION
This pull request deals with two issues #14 #27:

1. Per #14 it is neccary to change the EPISODE_PATH from `github/workflow` to `github/workspace`.

2. It seems `uses: Schrodinger-Hat/youtube-to-anchorfm@V0.1.8` Points to the latest published action not the latest code. That explains why the issue #25 address's wasn't implemented. Changing to `uses: Schrodinger-Hat/youtube-to-anchorfm@main` fix's that.

After the above changes I had a successful run.
It should be noted that in order to test my changes i changed  the yml file: `uses: Schrodinger-Hat/youtube-to-anchorfm@main` to my own repository `uses: abe-101/youtube-to-anchorfm@main`
It was tested with the flag `SAVE_AS_DRAFT: true`