### PR TITLE
Add YouTube URL to Podcast Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ env:
    LOAD_THUMBNAIL: true
 ```
 
+## Add YouTube URL to Podcast Description
+
+By setting the `URL_IN_DESCRIPTION`, the Podcast description will include the YouTube URL on a new line at the end of the description.
+It is recommended to set it, for if the YouTube video has no description it will fail to save the new episode. Setting it to true guarantees to always have a description.
+
+```yaml
+env:
+   URL_IN_DESCRIPTION: true
+```
+
+
 # Credits
 
 [@thejoin](https://github.com/thejoin95) & [@wabri](https://github.com/wabri)

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ const thumbnailMode = GetEnvironmentVar('LOAD_THUMBNAIL', 'false')
 const isExplicit = GetEnvironmentVar('IS_EXPLICIT', 'false')
 const selectorForExplicitContentLabel = isExplicit == 'true' ? 'label[for="podcastEpisodeIsExplicit-true"]' : 'label[for="podcastEpisodeIsExplicit-false"]'
 
+const urlDescription = GetEnvironmentVar('URL_IN_DESCRIPTION', 'false')
+
 // Allow fine tunning of the converted audio file
 // Example: "ffmpeg:-ac 1" for mono mp3
 const postprocessorArgs = GetEnvironmentVar('POSTPROCESSOR_ARGS', "")
@@ -56,7 +58,8 @@ exec('sudo curl -k -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/
         youtubedl.getInfo(url, function (err, info) {
             if (err) throw err;
             epConfJSON.title = info.title;
-            epConfJSON.description = info.description;
+            epConfJSON.description = urlDescription !== 'false' ? info.description + '\n' + url : info.description;
+
 
             console.log(`title: ${epConfJSON.title}`)
             console.log(`description: ${epConfJSON.description}`)


### PR DESCRIPTION
Using this tool I came across a bug when a YouTube video has no description it will fail to save the  episode. 
This is because anchor.fm requires one to put a description into the podcast and it won't let you press save till you do so.

One solution is to offer an env flag to add the YouTube URL to the bottom of the description, thereby when set to true it guarantees to always have a description.