### PR TITLE
Improve instructions on POSTPROCESSOR_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,15 @@ The example below convert the video to mono audio.
 
 ```yaml
 env:
-  POSTPROCESSOR_ARGS: 'ffmpeg:-ac 1'
+  POSTPROCESSOR_ARGS: 'ExtractAudio+ffmpeg:-ac 1'
+```
+
+To convert to mono audio, remove initial silence and apply fade-in:
+
+```yaml
+# remove initial silence quieter than -50dB
+env:
+  POSTPROCESSOR_ARGS: "ExtractAudio+ffmpeg:-ac 1 -af silenceremove=1:0:-50dB,afade=t=in:d=5"
 ```
 
 ### Explicit Mode


### PR DESCRIPTION
Newer versions of yt-dlp need to know at which conversion phase apply the audio filters (in this case on `ExtractAudio` phase).

Have been using for quite some time now in my repo.