### PR TITLE
Changed language selector

### DIFF
--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -106,7 +106,7 @@ async function postEpisode(youtubeVideoInfo) {
 
   async function setLanguageToEnglish() {
     await clickSelector(page, 'button[aria-label="Change language"]');
-    await clickSelector(page, 'div[aria-label="Language selection modal"] a[data-testid="language-option-en"]');
+    await clickSelector(page, '[data-testid="language-option-en"]');
   }
 
   async function login() {


### PR DESCRIPTION
As discussed previously into #106 locally i was having problems with the language selector. 

At the time the problem was not propagated into the action so the change was not merged into main.

But diving into #112 i found that the problem was the option details filling. 
The problem here might be that the id of the 'Promotional content' is not matching the id expected into the code without the language selector fix during the action process with the old selector.

With the fix instead the action runs smoothly without errors. 

Any opinion on this?