### PR TITLE
Added new login with spotify

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,4 @@
 ANCHOR_EMAIL=user@domain
 ANCHOR_PASSWORD=password
+SPOTIFY_EMAIL=user@domain
+SPOTIFY_PASSWORD=password

--- a/.github/workflows/upload-test.yml
+++ b/.github/workflows/upload-test.yml
@@ -16,4 +16,6 @@ jobs:
         env:
           ANCHOR_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
           ANCHOR_PASSWORD: ${{ secrets.ANCHOR_PASSWORD }}
+          SPOTIFY_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
+          SPOTIFY_PASSWORD: ${{ secrets.SPOTIFY_PASSWORD }}
           EPISODE_PATH: /github/workspace

--- a/.github/workflows/upload-test.yml
+++ b/.github/workflows/upload-test.yml
@@ -16,6 +16,6 @@ jobs:
         env:
           ANCHOR_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
           ANCHOR_PASSWORD: ${{ secrets.ANCHOR_PASSWORD }}
-          SPOTIFY_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
+          SPOTIFY_EMAIL: ${{ secrets.SPOTIFY_EMAIL }}
           SPOTIFY_PASSWORD: ${{ secrets.SPOTIFY_PASSWORD }}
           EPISODE_PATH: /github/workspace

--- a/README.md
+++ b/README.md
@@ -67,17 +67,30 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Upload Episode from YouTube To Anchor.Fm
-        uses: Schrodinger-Hat/youtube-to-anchorfm@v2.0.0
+        uses: Schrodinger-Hat/youtube-to-anchorfm@v2.3.0
         env:
           ANCHOR_EMAIL: ${{ secrets.ANCHOR_EMAIL }}
           ANCHOR_PASSWORD: ${{ secrets.ANCHOR_PASSWORD }}
+          SPOTIFY_EMAIL: ${{ secrets.SPOTIFY_EMAIL }}
+          SPOTIFY_PASSWORD: ${{ secrets.SPOTIFY_PASSWORD }}
           EPISODE_PATH: /github/workspace
 ```
 
-**NOTE**: you need to [set up the secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for _ANCHOR_EMAIL_ and _ANCHOR_PASSWORD_. This environment variables are mandatory as they specify the sign in account.
+**NOTE**: you need to [set up the secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) for _ANCHOR_EMAIL_ and _ANCHOR_PASSWORD_. This environment variables are mandatory as they specify the sign in account. 
+
+Instead the _SPOTIFY_EMAIL_ and _SPOTIFY_PASSWORD_ are not mandatory but can still be set, if needed, and will be used for the new login form if the env variable _ANCHOR_LOGIN_ is set to false.
 
 
 ## Environment variables
+
+### Login Type
+
+Setting the `ANCHOR_LOGIN` to true makes the script login with the old anchor login type. Instead setting it to false makes the script login with the spotify account. By default the value is true.
+
+```yaml
+env:
+  ANCHOR_LOGIN: true
+```
 
 ### Draft Mode
 
@@ -203,6 +216,8 @@ jobs:
         env:
           ANCHOR_EMAIL: ${{ secrets.ANCHOR_EMAIL_GREATNEWS}}  # OR secrets.ANCHOR_EMAIL_SADNEWS 
           ANCHOR_PASSWORD: ${{ secrets.ANCHOR_PASSWORD_GREATNEWS }}  # OR secrets.ANCHOR_PASSWORD_SADNEWS
+          SPOTIFY_EMAIL: ${{ secrets.SPOTIFY_EMAIL_GREATNEWS }}  # OR secrets.SPOTIFY_EMAIL_SADNEWS
+          SPOTIFY_PASSWORD: ${{ secrets.SPOTIFY_PASSWORD_GREATNEWS }}  # OR secrets.SPOTIFY_PASSWORD_SADNEWS
           EPISODE_PATH: /github/workspace/
           EPISODE_FILE: great-news.json
           # (…) Other configs as needed
@@ -224,6 +239,8 @@ To do that, you can copy `.env.sample` into a file with name `.env`.
 
 Make sure to specify the mandatory environment variables for logging in to Anchor.fm,
 `ANCHOR_EMAIL` and `ANCHOR_PASSWORD`.
+
+If needed we can set the `SPOTIFY_EMAIL` and `SPOTIFY_PASSWORD` too, so they will be used to login with the new login type after changing `ANCHOR_LOGIN` to false.
 
 Finally, you can do `npm start` to execute the script.
 

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -110,6 +110,14 @@ async function postEpisode(youtubeVideoInfo) {
   }
 
   async function login() {
+    if (env.ANCHOR_LOGIN) {
+      await anchorLogin();
+    } else {
+      await spotifyLogin();
+    }
+  }
+
+  async function anchorLogin() {
     console.log('-- Accessing Spotify for Podcasters login page');
     await clickXpath(page, '//button[contains(text(), "Continue")]');
 
@@ -127,6 +135,21 @@ async function postEpisode(youtubeVideoInfo) {
     console.log('-- Logged in');
   }
 
+  async function spotifyLogin() {
+    console.log('-- Accessing new Spotify login page for podcasts');
+    await clickXpath(page, '//span[contains(text(), "Continue with Spotify")]/parent::button');
+    console.log('-- Logging in');
+    
+    await page.waitForSelector('#login-username');
+    await page.type('#login-username', env.SPOTIFY_EMAIL);
+    await page.type('#login-password', env.SPOTIFY_PASSWORD);
+    await sleepSeconds(1);
+    await clickSelector(page, 'button[id="login-button"]');
+    await clickSelector(page, 'button[data-testid="auth-accept"]');
+    await page.waitForNavigation();
+    console.log('-- In the app');
+  }
+  
   async function waitForNewEpisodeWizard() {
     await sleepSeconds(1);
     console.log('-- Waiting for episode wizard to open');

--- a/src/environment-variables/index.js
+++ b/src/environment-variables/index.js
@@ -4,8 +4,11 @@ const dotenv = require('dotenv');
 const defaultValues = {
   EPISODE_PATH: '.',
   EPISODE_FILE: 'episode.json',
+  ANCHOR_LOGIN: true,
   ANCHOR_EMAIL: '',
   ANCHOR_PASSWORD: '',
+  SPOTIFY_EMAIL: '',
+  SPOTIFY_PASSWORD: '',
   UPLOAD_TIMEOUT: 60 * 5 * 1000,
   SAVE_AS_DRAFT: false,
   LOAD_THUMBNAIL: false,
@@ -63,8 +66,11 @@ function getCompleteEpisodePath() {
 
 module.exports = {
   EPISODE_PATH: getCompleteEpisodePath(),
+  ANCHOR_LOGIN: getBoolean(getEnvironmentVariable('ANCHOR_LOGIN')),
   ANCHOR_EMAIL: getEnvironmentVariable('ANCHOR_EMAIL'),
   ANCHOR_PASSWORD: getEnvironmentVariable('ANCHOR_PASSWORD'),
+  SPOTIFY_EMAIL: getEnvironmentVariable('SPOTIFY_EMAIL'),
+  SPOTIFY_PASSWORD: getEnvironmentVariable('SPOTIFY_PASSWORD'),
   UPLOAD_TIMEOUT: getEnvironmentVariable('UPLOAD_TIMEOUT'),
   SAVE_AS_DRAFT: getBoolean(getEnvironmentVariable('SAVE_AS_DRAFT')),
   LOAD_THUMBNAIL: getBoolean(getEnvironmentVariable('LOAD_THUMBNAIL')),


### PR DESCRIPTION
As discussed into #107 the old anchor account is deprecated for new users. 

So in this PR i've implemented the new login process using the spotify account. That can be activated setting the ```ANCHOR_LOGIN``` env variable to ```false```. 

By default that's set to ```true``` so up to now the anchor login remains the default one.

I've added to the yaml file the new secrets for running the action with ```SPOTIFY_EMAIL``` and ```SPOTIFY_PASSWORD```, so here could be worth updating the action and .env docs too? I've already updated the ```.env.sample``` in this commit with the new env variables.

Any opinion on this?